### PR TITLE
KPropertyAlias -> KParameterAlias

### DIFF
--- a/src/main/kotlin/com/mapk/annotations/KParameterAlias.kt
+++ b/src/main/kotlin/com/mapk/annotations/KParameterAlias.kt
@@ -2,4 +2,4 @@ package com.mapk.annotations
 
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class KPropertyAlias(val value: String)
+annotation class KParameterAlias(val value: String)


### PR DESCRIPTION
元は`KGetterAlias`と合わせて`KPropertyAlias`という名称だったが、`KGetterAlias`を分離したため、このアノテーションの名前は`KParameterAlias`とするのが正しかったため、修正を行った。