### PR TITLE
Added support for mapping with default arguments.

### DIFF
--- a/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
@@ -25,7 +25,7 @@ class ArgumentBucket internal constructor(
     private var initializationStatus: Int,
     private val initializeMask: List<Int>,
     private val completionValue: Int
-) : Cloneable {
+) {
     val isInitialized: Boolean get() = initializationStatus == completionValue
 
     fun setArgument(kParameter: KParameter, argument: Any?) {
@@ -38,15 +38,5 @@ class ArgumentBucket internal constructor(
         bucketMap[kParameter] = argument
         bucket[index] = argument
         initializationStatus = temp
-    }
-
-    public override fun clone(): ArgumentBucket {
-        return ArgumentBucket(
-            bucket.copyOf(),
-            bucketMap.toMutableMap(),
-            initializationStatus,
-            initializeMask,
-            completionValue
-        )
     }
 }

--- a/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
@@ -1,7 +1,10 @@
 package com.mapk.core
 
+import kotlin.reflect.KParameter
+
 class ArgumentBucket internal constructor(
     internal val bucket: Array<Any?>,
+    internal val bucketMap: MutableMap<KParameter, Any?>,
     private var initializationStatus: Int,
     private val initializeMask: List<Int>,
     // clone時の再計算を避けるため1回で済むようにデフォルト値化
@@ -12,12 +15,14 @@ class ArgumentBucket internal constructor(
         initializationStatus and initializeMask[it] == 0
     }
 
-    fun setArgument(argument: Any?, index: Int) {
+    fun setArgument(kParameter: KParameter, argument: Any?) {
+        val index = kParameter.index
         val temp = initializationStatus or initializeMask[index]
 
         // 先に入ったものを優先するため、初期化済みなら何もしない
         if (initializationStatus == temp) return
 
+        bucketMap[kParameter] = argument
         bucket[index] = argument
         initializationStatus = temp
     }
@@ -25,6 +30,7 @@ class ArgumentBucket internal constructor(
     public override fun clone(): ArgumentBucket {
         return ArgumentBucket(
             bucket.copyOf(),
+            bucketMap.toMutableMap(),
             initializationStatus,
             initializeMask,
             completionValue

--- a/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
@@ -4,19 +4,25 @@ import kotlin.reflect.KParameter
 
 internal class BucketGenerator(
     private val bucket: Array<Any?>,
-    private val bucketMap: MutableMap<KParameter, Any?>,
+    private val instancePair: Pair<KParameter, Any?>?,
     private val initializationStatus: Int,
     private val initializeMask: List<Int>
 ) {
     private val completionValue: Int = initializeMask.reduce { l, r -> l or r }
+    private val bucketSize = bucket.size
 
-    fun generate(): ArgumentBucket = ArgumentBucket(
-        bucket.copyOf(),
-        bucketMap.toMutableMap(),
-        initializationStatus,
-        initializeMask,
-        completionValue
-    )
+    fun generate(): ArgumentBucket {
+        val tempMap = HashMap<KParameter, Any?>(bucketSize, 1.0f)
+        instancePair?.run { tempMap[this.first] = this.second }
+
+        return ArgumentBucket(
+            bucket.copyOf(),
+            tempMap,
+            initializationStatus,
+            initializeMask,
+            completionValue
+        )
+    }
 }
 
 class ArgumentBucket internal constructor(

--- a/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
@@ -11,9 +11,6 @@ class ArgumentBucket internal constructor(
     private val completionValue: Int = initializeMask.reduce { l, r -> l or r }
 ) : Cloneable {
     val isInitialized: Boolean get() = initializationStatus == completionValue
-    val notInitializedParameterIndexes: List<Int> get() = initializeMask.indices.filter {
-        initializationStatus and initializeMask[it] == 0
-    }
 
     fun setArgument(kParameter: KParameter, argument: Any?) {
         val index = kParameter.index

--- a/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
@@ -2,13 +2,29 @@ package com.mapk.core
 
 import kotlin.reflect.KParameter
 
+internal class BucketGenerator(
+    private val bucket: Array<Any?>,
+    private val bucketMap: MutableMap<KParameter, Any?>,
+    private val initializationStatus: Int,
+    private val initializeMask: List<Int>
+) {
+    private val completionValue: Int = initializeMask.reduce { l, r -> l or r }
+
+    fun generate(): ArgumentBucket = ArgumentBucket(
+        bucket.copyOf(),
+        bucketMap.toMutableMap(),
+        initializationStatus,
+        initializeMask,
+        completionValue
+    )
+}
+
 class ArgumentBucket internal constructor(
     internal val bucket: Array<Any?>,
     internal val bucketMap: MutableMap<KParameter, Any?>,
     private var initializationStatus: Int,
     private val initializeMask: List<Int>,
-    // clone時の再計算を避けるため1回で済むようにデフォルト値化
-    private val completionValue: Int = initializeMask.reduce { l, r -> l or r }
+    private val completionValue: Int
 ) : Cloneable {
     val isInitialized: Boolean get() = initializationStatus == completionValue
 

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -34,7 +34,7 @@ class KFunctionForCall<T>(private val function: KFunction<T>, instance: Any? = n
 
     fun getArgumentBucket(): ArgumentBucket = originalArgumentBucket.clone()
 
-    fun call(argumentBucket: ArgumentBucket): T {
-        return function.call(*argumentBucket.bucket)
-    }
+    fun call(argumentBucket: ArgumentBucket): T =
+        if (argumentBucket.isInitialized) function.call(*argumentBucket.bucket)
+        else function.callBy(argumentBucket.bucketMap)
 }

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -16,19 +16,16 @@ class KFunctionForCall<T>(private val function: KFunction<T>, instance: Any? = n
         function.isAccessible = true
 
         // 初期化処理の共通化のため先に初期化
-        val tempMap = HashMap<KParameter, Any?>(parameters.size, 1.0f)
         val tempArray = Array<Any?>(parameters.size) { null }
         val maskList = generateSequence(1) { it.shl(1) }.take(parameters.size).toList()
 
         generator = if (instance != null) {
-            // インスタンス有りでは先にインスタンスを初期化する
-            parameters.find { it.kind == KParameter.Kind.INSTANCE }?.run { tempMap[this] = instance }
             tempArray[0] = instance
 
             // 引数の1番目は初期化済みということでinitializationStatusは1スタート
-            BucketGenerator(tempArray, tempMap, 1, maskList)
+            BucketGenerator(tempArray, parameters.first { it.kind == KParameter.Kind.INSTANCE } to instance, 1, maskList)
         } else {
-            BucketGenerator(tempArray, tempMap, 0, maskList)
+            BucketGenerator(tempArray, null, 0, maskList)
         }
     }
 

--- a/src/test/kotlin/com/mapk/core/ArgumentBucketTest.kt
+++ b/src/test/kotlin/com/mapk/core/ArgumentBucketTest.kt
@@ -36,9 +36,10 @@ class ArgumentBucketTest {
         @Test
         @DisplayName("初期化後")
         fun isInitialized() {
-            argumentBucket.setArgument(object {}, 0)
-            argumentBucket.setArgument(object {}, 1)
-            argumentBucket.setArgument(object {}, 2)
+            ::sampleFunction.parameters.forEach {
+                argumentBucket.setArgument(it, object {})
+            }
+
             assertTrue(argumentBucket.isInitialized)
         }
     }

--- a/src/test/kotlin/com/mapk/core/ArgumentBucketTest.kt
+++ b/src/test/kotlin/com/mapk/core/ArgumentBucketTest.kt
@@ -49,15 +49,18 @@ class ArgumentBucketTest {
         @Test
         @DisplayName("正常に追加した場合")
         fun setNewArgument() {
-            argumentBucket.setArgument("argument", 0)
+            val parameter = ::sampleFunction.parameters.first { it.index == 0 }
+            argumentBucket.setArgument(parameter, "argument")
             assertEquals("argument", argumentBucket.bucket[0])
         }
 
         @Test
         @DisplayName("同じインデックスに2回追加した場合")
         fun setArgumentTwice() {
-            argumentBucket.setArgument("first", 0)
-            argumentBucket.setArgument("second", 0)
+            val parameter = ::sampleFunction.parameters.first { it.index == 0 }
+
+            argumentBucket.setArgument(parameter, "first")
+            argumentBucket.setArgument(parameter, "second")
             assertEquals("first", argumentBucket.bucket[0])
         }
     }

--- a/src/test/kotlin/com/mapk/core/ArgumentBucketTest.kt
+++ b/src/test/kotlin/com/mapk/core/ArgumentBucketTest.kt
@@ -2,7 +2,6 @@ package com.mapk.core
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertIterableEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -41,32 +40,6 @@ class ArgumentBucketTest {
             }
 
             assertTrue(argumentBucket.isInitialized)
-        }
-    }
-
-    @Nested
-    @DisplayName("初期化されていないインデックス取得のテスト")
-    inner class NotInitializedParameterIndexesTest {
-        @Test
-        @DisplayName("何もセットしていない場合")
-        fun noArguments() {
-            assertIterableEquals(listOf(0, 1, 2), argumentBucket.notInitializedParameterIndexes)
-        }
-
-        @Test
-        @DisplayName("1つセットした場合")
-        fun singleArgument() {
-            argumentBucket.setArgument(object {}, 1)
-            assertIterableEquals(listOf(0, 2), argumentBucket.notInitializedParameterIndexes)
-        }
-
-        @Test
-        @DisplayName("全てセットした場合")
-        fun fullArguments() {
-            argumentBucket.setArgument(object {}, 0)
-            argumentBucket.setArgument(object {}, 1)
-            argumentBucket.setArgument(object {}, 2)
-            assertIterableEquals(emptyList<Any?>(), argumentBucket.notInitializedParameterIndexes)
         }
     }
 

--- a/src/test/kotlin/com/mapk/core/KFunctionForCallTest.kt
+++ b/src/test/kotlin/com/mapk/core/KFunctionForCallTest.kt
@@ -1,5 +1,7 @@
 package com.mapk.core
 
+import kotlin.reflect.full.functions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -31,6 +33,30 @@ class KFunctionForCallTest {
         @DisplayName("正常入力")
         fun isValid() {
             assertDoesNotThrow { KFunctionForCall(this::dummy2) }
+        }
+    }
+
+    @Nested
+    @DisplayName("呼び出し関連テスト")
+    inner class CallTest {
+        @Test
+        @DisplayName("コンパニオンオブジェクトから取得した場合")
+        fun fromCompanionObject() {
+            val function =
+                Companion::class.functions.find { it.name == (KFunctionForCallTest)::declaredOnCompanionObject.name }!!
+
+            val kFunctionForCall = KFunctionForCall(function, Companion)
+
+            val bucket = kFunctionForCall.getArgumentBucket()
+            kFunctionForCall.parameters.forEach { bucket.setArgument(it, it.index) }
+            val result = kFunctionForCall.call(bucket)
+            assertEquals("12", result)
+        }
+    }
+
+    companion object {
+        fun declaredOnCompanionObject(arg1: Any, arg2: Any): String {
+            return arg1.toString() + arg2.toString()
         }
     }
 }

--- a/src/test/kotlin/com/mapk/core/KFunctionForCallTest.kt
+++ b/src/test/kotlin/com/mapk/core/KFunctionForCallTest.kt
@@ -52,6 +52,20 @@ class KFunctionForCallTest {
             val result = kFunctionForCall.call(bucket)
             assertEquals("12", result)
         }
+
+        private fun func(key: String, value: String = "default"): Pair<String, String> = key to value
+
+        @Test
+        @DisplayName("デフォルト値を用いる場合")
+        fun useDefaultValue() {
+            val kFunctionForCall = KFunctionForCall(::func)
+            val argumentBucket = kFunctionForCall.getArgumentBucket()
+
+            ::func.parameters.forEach { if (!it.isOptional) argumentBucket.setArgument(it, it.name) }
+
+            val result = kFunctionForCall.call(argumentBucket)
+            assertEquals("key" to "default", result)
+        }
     }
 
     companion object {


### PR DESCRIPTION
# 内容
- 「引数全体の初期化が済んでいる場合は`call`、それ以外の場合は`callBy`」と呼び分けることで、引数が足りなかった場合はデフォルト引数が用いられるように修正
  - これに伴い、どのパラメータが足りなかったかは`callBy`で分かるようになったため、`notInitializedParameterIndexes`を削除
- 呼び出しに関する一部テストを追加