### PR TITLE
Update and fix ArgumentBucket.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     implementation(group = "org.jetbrains", name = "annotations", version = "19.0.0")
 
     // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter
-    testImplementation(group = "org.junit.jupiter", name = "junit-jupiter", version = "5.6.0") {
+    testImplementation(group = "org.junit.jupiter", name = "junit-jupiter", version = "5.6.1") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
     // https://mvnrepository.com/artifact/io.mockk/mockk

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.9"
+version = "0.10"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("maven")
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.3.70"
+    id("org.jetbrains.kotlin.jvm") version "1.3.71"
     id("org.jlleitschuh.gradle.ktlint") version "9.2.1"
 }
 
@@ -18,7 +18,7 @@ buildscript {
     }
 
     dependencies {
-        classpath(kotlin("gradle-plugin", version = "1.3.70"))
+        classpath(kotlin("gradle-plugin", version = "1.3.71"))
     }
 }
 

--- a/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
@@ -37,10 +37,10 @@ class ArgumentBucket internal constructor(
 
     override val entries: Set<Map.Entry<KParameter, Any?>>
         get() = keyArray.mapNotNull { it?.let { Entry(it, valueArray[it.index]) } }.toSet()
-    override val keys: MutableSet<KParameter>
-        get() = keyArray.filterNotNull().toMutableSet()
-    override val values: MutableCollection<Any?>
-        get() = valueArray.filterIndexed { i, _ -> initializationStatusManager.isInitialized(i) }.toMutableList()
+    override val keys: Set<KParameter>
+        get() = keyArray.filterNotNull().toSet()
+    override val values: Collection<Any?>
+        get() = valueArray.filterIndexed { i, _ -> initializationStatusManager.isInitialized(i) }
 
     fun putIfAbsent(key: KParameter, value: Any?) {
         val index = key.index

--- a/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentBucket.kt
@@ -4,7 +4,7 @@ import java.util.Objects
 import kotlin.reflect.KParameter
 
 class ArgumentBucket internal constructor(
-    private val keyArray: Array<KParameter?>,
+    private val keyList: List<KParameter>,
     internal val valueArray: Array<Any?>,
     private val isRequireNonNull: List<Boolean>,
     private val initializationStatusManager: InitializationStatusManager
@@ -22,8 +22,7 @@ class ArgumentBucket internal constructor(
     override val size: Int get() = count
 
     override fun containsKey(key: KParameter): Boolean {
-        // NOTE: もしかしたらステータスを見た方が速いかも
-        return keyArray[key.index] != null
+        return initializationStatusManager.isInitialized(key.index)
     }
 
     override fun containsValue(value: Any?): Boolean = valueArray.any { Objects.equals(value, it) }
@@ -36,9 +35,12 @@ class ArgumentBucket internal constructor(
     override fun isEmpty(): Boolean = count == 0
 
     override val entries: Set<Map.Entry<KParameter, Any?>>
-        get() = keyArray.mapNotNull { it?.let { Entry(it, valueArray[it.index]) } }.toSet()
+        get() = keyList
+            .filter { initializationStatusManager.isInitialized(it.index) }
+            .map { Entry(it, valueArray[it.index]) }
+            .toSet()
     override val keys: Set<KParameter>
-        get() = keyArray.filterNotNull().toSet()
+        get() = keyList.filter { initializationStatusManager.isInitialized(it.index) }.toSet()
     override val values: Collection<Any?>
         get() = valueArray.filterIndexed { i, _ -> initializationStatusManager.isInitialized(i) }
 
@@ -53,7 +55,6 @@ class ArgumentBucket internal constructor(
 
         count += 1
         initializationStatusManager.put(index)
-        keyArray[index] = key
         valueArray[index] = value
 
         return

--- a/src/main/kotlin/com/mapk/core/BucketGenerator.kt
+++ b/src/main/kotlin/com/mapk/core/BucketGenerator.kt
@@ -3,10 +3,9 @@ package com.mapk.core
 import com.mapk.annotations.KParameterRequireNonNull
 import kotlin.reflect.KParameter
 
-internal class BucketGenerator(parameters: List<KParameter>, instancePair: Pair<KParameter, Any>?) {
+internal class BucketGenerator(private val parameters: List<KParameter>, instance: Any?) {
     private val initializationStatus: Array<Boolean>
     private val isRequireNonNull: List<Boolean>
-    private val keyArray: Array<KParameter?>
     private val valueArray: Array<Any?>
 
     init {
@@ -16,12 +15,10 @@ internal class BucketGenerator(parameters: List<KParameter>, instancePair: Pair<
         }
         initializationStatus = Array(capacity) { false }
 
-        keyArray = arrayOfNulls(capacity)
         valueArray = arrayOfNulls(capacity)
 
-        if (instancePair != null) {
-            keyArray[0] = instancePair.first
-            valueArray[0] = instancePair.second
+        if (instance != null) {
+            valueArray[0] = instance
             initializationStatus[0] = true
         } else {
             initializationStatus[0] = false
@@ -30,7 +27,7 @@ internal class BucketGenerator(parameters: List<KParameter>, instancePair: Pair<
 
     fun generate(): ArgumentBucket {
         return ArgumentBucket(
-            keyArray.clone(),
+            parameters,
             valueArray.clone(),
             isRequireNonNull,
             InitializationStatusManager(initializationStatus.clone())

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -20,9 +20,8 @@ class KFunctionForCall<T>(internal val function: KFunction<T>, instance: Any? = 
         // この関数には確実にアクセスするためアクセシビリティ書き換え
         function.isAccessible = true
 
-        generator = BucketGenerator(
-            parameters, instance?.let { parameters.first { param -> param.kind == KParameter.Kind.INSTANCE } to it }
-        )
+        // パラメータのチェックを済ませてから初期化しないとエラーになる
+        generator = BucketGenerator(parameters, instance)
     }
 
     fun getArgumentBucket(): ArgumentBucket = generator.generate()


### PR DESCRIPTION
# アップデート
- `kotlin` 1.3.70 -> 1.3.71
- `junit jupiter` 5.6.0 -> 5.6.1

# 修正
- `keyArray`として`KParameter`を取っていたが、これは初期化時点で決まる値だったため、`keyList`として`immutable`に扱うように修正
  - `keyArray`を用いて行っていた`contains`判定を修正
  - `keyArray‘の`nullability`を用いて行っていた初期化判定を修正
- `keys`/`values`がそれぞれ`Mutable`な`Collection`を返していた問題を修正