### PR TITLE
Added a mapping function with flattened parameters.

### DIFF
--- a/src/main/kotlin/com/mapk/annotations/KParameterFlatten.kt
+++ b/src/main/kotlin/com/mapk/annotations/KParameterFlatten.kt
@@ -8,5 +8,5 @@ import kotlin.reflect.KClass
 @MustBeDocumented
 annotation class KParameterFlatten(
     val fieldNameToPrefix: Boolean = true,
-    val namingConvention: KClass<out NameJoiner>
+    val namingConvention: KClass<out NameJoiner> = NameJoiner.Camel::class
 )

--- a/src/main/kotlin/com/mapk/annotations/KParameterFlatten.kt
+++ b/src/main/kotlin/com/mapk/annotations/KParameterFlatten.kt
@@ -8,5 +8,5 @@ import kotlin.reflect.KClass
 @MustBeDocumented
 annotation class KParameterFlatten(
     val fieldNameToPrefix: Boolean = true,
-    val namingConvention: KClass<out NameJoiner> = NameJoiner.Camel::class
+    val nameJoiner: KClass<out NameJoiner> = NameJoiner.Camel::class
 )

--- a/src/main/kotlin/com/mapk/annotations/KParameterFlatten.kt
+++ b/src/main/kotlin/com/mapk/annotations/KParameterFlatten.kt
@@ -1,0 +1,12 @@
+package com.mapk.annotations
+
+import com.mapk.core.NameJoiner
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+annotation class KParameterFlatten(
+    val fieldNameToPrefix: Boolean = true,
+    val namingConvention: KClass<out NameJoiner>
+)

--- a/src/main/kotlin/com/mapk/core/ArgumentAdaptor.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentAdaptor.kt
@@ -13,7 +13,9 @@ class ArgumentAdaptor(private val requiredParameters: Map<String, ValueParameter
     }
 
     fun putIfAbsent(key: String, value: Any?) {
-        if (!isInitialized(key)) argumentMap[key] = value
+        if (!isInitialized(key) && (!requiredParameters.getValue(key).isNullable && value == null)) {
+            argumentMap[key] = value
+        }
     }
 
     // 事前に存在チェックはやるものと仮定してここでは読み出しだけ実装

--- a/src/main/kotlin/com/mapk/core/ArgumentAdaptor.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentAdaptor.kt
@@ -13,7 +13,7 @@ class ArgumentAdaptor(private val requiredParameters: Map<String, ValueParameter
     }
 
     fun putIfAbsent(key: String, value: Any?) {
-        if (!isInitialized(key) && (!requiredParameters.getValue(key).isNullable && value == null)) {
+        if (!isInitialized(key) && !(requiredParameters.getValue(key).isNullable && value == null)) {
             argumentMap[key] = value
         }
     }

--- a/src/main/kotlin/com/mapk/core/ArgumentBinder.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentBinder.kt
@@ -35,6 +35,8 @@ internal sealed class ArgumentBinder(val annotations: List<Annotation>) {
         override val index: Int,
         annotations: List<Annotation>
     ) : ArgumentBinder(annotations) {
+        val requiredParameters: List<ValueParameter<*>> = function.requiredParameters
+
         override fun bindArgument(adaptor: ArgumentAdaptor, valueArray: Array<Any?>): Boolean {
             val temp = function.call(adaptor)
 

--- a/src/main/kotlin/com/mapk/core/ArgumentBinder.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentBinder.kt
@@ -1,7 +1,7 @@
 package com.mapk.core
 
 // TODO: 関数バインダーの追加
-sealed class ArgumentBinder {
+internal sealed class ArgumentBinder {
     abstract val index: Int
 
     /**

--- a/src/main/kotlin/com/mapk/core/ArgumentBinder.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentBinder.kt
@@ -1,7 +1,11 @@
 package com.mapk.core
 
-internal sealed class ArgumentBinder {
+import com.mapk.annotations.KParameterRequireNonNull
+import kotlin.reflect.KClass
+
+internal sealed class ArgumentBinder(val annotations: List<Annotation>) {
     abstract val index: Int
+    val isNullable: Boolean = annotations.none { it is KParameterRequireNonNull }
 
     /**
      * 初期化されており、かつ読み出し条件に合致すれば読み出してその値をバインド、されていなければ何もしない
@@ -9,10 +13,16 @@ internal sealed class ArgumentBinder {
      */
     abstract fun bindArgument(adaptor: ArgumentAdaptor, valueArray: Array<Any?>): Boolean
 
-    class Value(private val key: String, override val index: Int) : ArgumentBinder() {
+    class Value<T : Any>(
+        override val index: Int,
+        annotations: List<Annotation>,
+        override val isOptional: Boolean,
+        override val name: String,
+        override val requiredClazz: KClass<T>
+    ) : ArgumentBinder(annotations), ValueParameter<T> {
         override fun bindArgument(adaptor: ArgumentAdaptor, valueArray: Array<Any?>): Boolean {
-            return if (adaptor.isInitialized(key)) {
-                valueArray[index] = adaptor.readout(key)
+            return if (adaptor.isInitialized(name)) {
+                valueArray[index] = adaptor.readout(name)
                 true
             } else {
                 false
@@ -22,8 +32,9 @@ internal sealed class ArgumentBinder {
 
     class Function(
         private val function: KFunctionForCall<*>,
-        override val index: Int
-    ) : ArgumentBinder() {
+        override val index: Int,
+        annotations: List<Annotation>
+    ) : ArgumentBinder(annotations) {
         override fun bindArgument(adaptor: ArgumentAdaptor, valueArray: Array<Any?>): Boolean {
             val temp = function.call(adaptor)
             valueArray[index] = temp

--- a/src/main/kotlin/com/mapk/core/ArgumentBinder.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentBinder.kt
@@ -1,6 +1,5 @@
 package com.mapk.core
 
-// TODO: 関数バインダーの追加
 internal sealed class ArgumentBinder {
     abstract val index: Int
 
@@ -18,6 +17,17 @@ internal sealed class ArgumentBinder {
             } else {
                 false
             }
+        }
+    }
+
+    class Function(
+        private val function: KFunctionForCall<*>,
+        override val index: Int
+    ) : ArgumentBinder() {
+        override fun bindArgument(adaptor: ArgumentAdaptor, valueArray: Array<Any?>): Boolean {
+            val temp = function.call(adaptor)
+            valueArray[index] = temp
+            return true
         }
     }
 }

--- a/src/main/kotlin/com/mapk/core/ArgumentBinder.kt
+++ b/src/main/kotlin/com/mapk/core/ArgumentBinder.kt
@@ -37,6 +37,9 @@ internal sealed class ArgumentBinder(val annotations: List<Annotation>) {
     ) : ArgumentBinder(annotations) {
         override fun bindArgument(adaptor: ArgumentAdaptor, valueArray: Array<Any?>): Boolean {
             val temp = function.call(adaptor)
+
+            if (!isNullable && temp == null) return false
+
             valueArray[index] = temp
             return true
         }

--- a/src/main/kotlin/com/mapk/core/BucketGenerator.kt
+++ b/src/main/kotlin/com/mapk/core/BucketGenerator.kt
@@ -9,7 +9,7 @@ internal class BucketGenerator(
     private val parameters: List<KParameter>,
     filteredParameters: List<KParameter>, // フィルタリングは外でもやっているため、ここでは引数として受け取る
     instance: Any?,
-    parameterNameConverter: (String) -> String
+    parameterNameConverter: ParameterNameConverter
 ) {
     private val binders: List<ArgumentBinder>
     private val originalValueArray: Array<Any?>
@@ -22,9 +22,8 @@ internal class BucketGenerator(
 
             it.findAnnotation<KParameterFlatten>()?.let { annotation ->
                 // 名前の変換処理、結合が必要な場合はインスタンスを持ってきて対応する
-                val converter: (String) -> String = if (annotation.fieldNameToPrefix) {
-                    val joiner = annotation.nameJoiner.objectInstance!!
-                    { suffix -> parameterNameConverter(joiner.join(name, suffix)) }
+                val converter: ParameterNameConverter = if (annotation.fieldNameToPrefix) {
+                    parameterNameConverter.nest(name, annotation.nameJoiner.objectInstance!!)
                 } else {
                     parameterNameConverter
                 }
@@ -38,7 +37,7 @@ internal class BucketGenerator(
                 it.index,
                 it.annotations,
                 it.isOptional,
-                parameterNameConverter(name),
+                parameterNameConverter.convert(name),
                 it.type.classifier as KClass<*>
             )
         }

--- a/src/main/kotlin/com/mapk/core/BucketGenerator.kt
+++ b/src/main/kotlin/com/mapk/core/BucketGenerator.kt
@@ -30,9 +30,16 @@ internal class BucketGenerator(
 
                 ArgumentBinder.Function(
                     (it.type.classifier as KClass<*>).toKConstructor(converter),
-                    it.index
+                    it.index,
+                    it.annotations
                 )
-            } ?: ArgumentBinder.Value(parameterNameConverter(name), it.index)
+            } ?: ArgumentBinder.Value(
+                it.index,
+                it.annotations,
+                it.isOptional,
+                parameterNameConverter(name),
+                it.type.classifier as KClass<*>
+            )
         }
         // 配列系ではフィルタリング前のサイズが必要
         originalValueArray = arrayOfNulls(parameters.size)

--- a/src/main/kotlin/com/mapk/core/BucketGenerator.kt
+++ b/src/main/kotlin/com/mapk/core/BucketGenerator.kt
@@ -1,6 +1,9 @@
 package com.mapk.core
 
+import com.mapk.annotations.KParameterFlatten
+import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
+import kotlin.reflect.full.findAnnotation
 
 internal class BucketGenerator(
     private val parameters: List<KParameter>,
@@ -13,8 +16,24 @@ internal class BucketGenerator(
     private val originalInitializationStatus: Array<Boolean>
 
     init {
-        // TODO: ネスト関連への対応
-        binders = filteredParameters.map { ArgumentBinder.Value(parameterNameConverter(it.getAliasOrName()!!), it.index) }
+        binders = filteredParameters.map {
+            val name = it.getAliasOrName()!!
+
+            it.findAnnotation<KParameterFlatten>()?.let { annotation ->
+                // 名前の変換処理、結合が必要な場合はインスタンスを持ってきて対応する
+                val converter: (String) -> String = if (annotation.fieldNameToPrefix) {
+                    val joiner = annotation.namingConvention.objectInstance!!
+                    { suffix -> parameterNameConverter(joiner.join(name, suffix)) }
+                } else {
+                    parameterNameConverter
+                }
+
+                ArgumentBinder.Function(
+                    (it.type.classifier as KClass<*>).toKConstructor(converter),
+                    it.index
+                )
+            } ?: ArgumentBinder.Value(parameterNameConverter(name), it.index)
+        }
         // 配列系ではフィルタリング前のサイズが必要
         originalValueArray = arrayOfNulls(parameters.size)
         originalInitializationStatus = Array(parameters.size) { false }

--- a/src/main/kotlin/com/mapk/core/BucketGenerator.kt
+++ b/src/main/kotlin/com/mapk/core/BucketGenerator.kt
@@ -23,7 +23,7 @@ internal class BucketGenerator(
             it.findAnnotation<KParameterFlatten>()?.let { annotation ->
                 // 名前の変換処理、結合が必要な場合はインスタンスを持ってきて対応する
                 val converter: (String) -> String = if (annotation.fieldNameToPrefix) {
-                    val joiner = annotation.namingConvention.objectInstance!!
+                    val joiner = annotation.nameJoiner.objectInstance!!
                     { suffix -> parameterNameConverter(joiner.join(name, suffix)) }
                 } else {
                     parameterNameConverter

--- a/src/main/kotlin/com/mapk/core/BucketGenerator.kt
+++ b/src/main/kotlin/com/mapk/core/BucketGenerator.kt
@@ -14,6 +14,7 @@ internal class BucketGenerator(
     private val binders: List<ArgumentBinder>
     private val originalValueArray: Array<Any?>
     private val originalInitializationStatus: Array<Boolean>
+    val valueParameters: List<ValueParameter<*>>
 
     init {
         binders = filteredParameters.map {
@@ -47,6 +48,15 @@ internal class BucketGenerator(
         if (instance != null) {
             originalValueArray[0] = instance
             originalInitializationStatus[0] = true
+        }
+
+        // TODO: 仮置き、これを生成するのはKFunctionForCallの方が良さげ
+        valueParameters = binders.fold(ArrayList()) { acc, elm ->
+            when (elm) {
+                is ArgumentBinder.Value<*> -> acc.add(elm)
+                is ArgumentBinder.Function -> acc.addAll(elm.requiredParameters)
+            }
+            acc
         }
     }
 

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -11,6 +11,7 @@ import kotlin.reflect.jvm.isAccessible
 import org.jetbrains.annotations.TestOnly
 
 class KFunctionForCall<T>(
+    @TestOnly
     internal val function: KFunction<T>,
     parameterNameConverter: (String) -> String,
     instance: Any? = null

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -10,12 +10,18 @@ import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.isAccessible
 import org.jetbrains.annotations.TestOnly
 
-class KFunctionForCall<T>(
+class KFunctionForCall<T> internal constructor(
     @TestOnly
     internal val function: KFunction<T>,
-    parameterNameConverter: (String) -> String,
+    parameterNameConverter: ParameterNameConverter,
     instance: Any? = null
 ) {
+    constructor(function: KFunction<T>, parameterNameConverter: (String) -> String, instance: Any? = null) : this(
+        function,
+        ParameterNameConverter.Simple(parameterNameConverter),
+        instance
+    )
+
     @TestOnly
     internal val parameters: List<KParameter> = function.parameters
 
@@ -48,7 +54,7 @@ class KFunctionForCall<T>(
 }
 
 @Suppress("UNCHECKED_CAST")
-fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: (String) -> String): KFunctionForCall<T> {
+internal fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: ParameterNameConverter): KFunctionForCall<T> {
     val factoryConstructor: List<KFunctionForCall<T>> =
         this.companionObjectInstance?.let { companionObject ->
             companionObject::class.functions
@@ -66,3 +72,7 @@ fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: (String) -> Strin
 
     throw IllegalArgumentException("Find multiple target.")
 }
+
+@Suppress("UNCHECKED_CAST")
+fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: (String) -> String): KFunctionForCall<T> =
+    this.toKConstructor(ParameterNameConverter.Simple(parameterNameConverter))

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -18,6 +18,7 @@ class KFunctionForCall<T>(
     @TestOnly
     internal val parameters: List<KParameter> = function.parameters
 
+    // 上は外部への公開用、下はArgumentAdaptor生成用
     val requiredParameters: List<ValueParameter<*>>
     private val requiredParametersMap: Map<String, ValueParameter<*>>
 
@@ -31,10 +32,10 @@ class KFunctionForCall<T>(
         function.isAccessible = true
 
         val filteredParameters = parameters.filter { it.kind == KParameter.Kind.VALUE && !it.isUseDefaultArgument() }
-        requiredParameters = filteredParameters.map { ValueParameterImpl.newInstance(it, parameterNameConverter) }
-        requiredParametersMap = requiredParameters.associateBy { it.name }
-
         bucketGenerator = BucketGenerator(parameters, filteredParameters, instance, parameterNameConverter)
+
+        requiredParameters = bucketGenerator.valueParameters
+        requiredParametersMap = requiredParameters.associateBy { it.name }
     }
 
     fun getArgumentAdaptor(): ArgumentAdaptor = ArgumentAdaptor(requiredParametersMap)

--- a/src/main/kotlin/com/mapk/core/NameJoiner.kt
+++ b/src/main/kotlin/com/mapk/core/NameJoiner.kt
@@ -1,0 +1,27 @@
+package com.mapk.core
+
+abstract class NameJoiner {
+    abstract fun join(prefix: String, suffix: String): String
+
+    object Camel : NameJoiner() {
+        override fun join(prefix: String, suffix: String): String = when {
+            prefix == "" -> suffix
+            suffix == "" -> prefix
+            else -> "$prefix${suffix[0].toUpperCase()}${suffix.substring(1)}"
+        }
+    }
+    object Snake : NameJoiner() {
+        override fun join(prefix: String, suffix: String): String = when {
+            prefix == "" -> suffix
+            suffix == "" -> prefix
+            else -> "${prefix}_$suffix"
+        }
+    }
+    object Kebab : NameJoiner() {
+        override fun join(prefix: String, suffix: String): String = when {
+            prefix == "" -> suffix
+            suffix == "" -> prefix
+            else -> "$prefix-$suffix"
+        }
+    }
+}

--- a/src/main/kotlin/com/mapk/core/ParameterNameConverter.kt
+++ b/src/main/kotlin/com/mapk/core/ParameterNameConverter.kt
@@ -1,0 +1,24 @@
+package com.mapk.core
+
+internal sealed class ParameterNameConverter {
+    protected abstract val converter: (String) -> String
+    abstract fun convert(name: String): String
+    abstract fun nest(infix: String, nameJoiner: NameJoiner): WithPrefix
+
+    class Simple(override val converter: (String) -> String) : ParameterNameConverter() {
+        override fun convert(name: String) = converter(name)
+        override fun nest(infix: String, nameJoiner: NameJoiner) = WithPrefix(infix, nameJoiner, converter)
+    }
+
+    class WithPrefix(
+        prefix: String,
+        private val nameJoiner: NameJoiner,
+        override val converter: (String) -> String
+    ) : ParameterNameConverter() {
+        private val prefix = converter(prefix)
+
+        // 結合を伴う変換では、「双方変換 -> 結合」の順で処理を行う
+        override fun convert(name: String) = converter(name).let { nameJoiner.join(prefix, it) }
+        override fun nest(infix: String, nameJoiner: NameJoiner) = WithPrefix(convert(infix), nameJoiner, converter)
+    }
+}

--- a/src/main/kotlin/com/mapk/core/ValueParameter.kt
+++ b/src/main/kotlin/com/mapk/core/ValueParameter.kt
@@ -4,28 +4,28 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 
 interface ValueParameter<T : Any> {
-    val requiredClazz: KClass<T>
-    val name: String
     val annotations: List<Annotation>
     val isOptional: Boolean
+    val name: String
+    val requiredClazz: KClass<T>
 }
 
 // TODO: 仮置き、ArgumentBinder.Valueでimplementした方が良いと感じるが一旦実装を分けている
 internal class ValueParameterImpl<T : Any>(
-    override val requiredClazz: KClass<T>,
-    override val name: String,
     override val annotations: List<Annotation>,
-    override val isOptional: Boolean
+    override val isOptional: Boolean,
+    override val name: String,
+    override val requiredClazz: KClass<T>
 ) : ValueParameter<T> {
     companion object {
         fun newInstance(
             parameter: KParameter,
             parameterNameConverter: (String) -> String
         ): ValueParameter<*> = ValueParameterImpl(
-            parameter.type.classifier as KClass<*>,
-            parameterNameConverter(parameter.getAliasOrName()!!),
             parameter.annotations,
-            parameter.isOptional
+            parameter.isOptional,
+            parameterNameConverter(parameter.getAliasOrName()!!),
+            parameter.type.classifier as KClass<*>
         )
     }
 }

--- a/src/main/kotlin/com/mapk/core/ValueParameter.kt
+++ b/src/main/kotlin/com/mapk/core/ValueParameter.kt
@@ -1,10 +1,12 @@
 package com.mapk.core
 
+import com.mapk.annotations.KParameterRequireNonNull
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 
 interface ValueParameter<T : Any> {
     val annotations: List<Annotation>
+    val isNullable: Boolean
     val isOptional: Boolean
     val name: String
     val requiredClazz: KClass<T>
@@ -13,6 +15,7 @@ interface ValueParameter<T : Any> {
 // TODO: 仮置き、ArgumentBinder.Valueでimplementした方が良いと感じるが一旦実装を分けている
 internal class ValueParameterImpl<T : Any>(
     override val annotations: List<Annotation>,
+    override val isNullable: Boolean,
     override val isOptional: Boolean,
     override val name: String,
     override val requiredClazz: KClass<T>
@@ -23,6 +26,7 @@ internal class ValueParameterImpl<T : Any>(
             parameterNameConverter: (String) -> String
         ): ValueParameter<*> = ValueParameterImpl(
             parameter.annotations,
+            parameter.annotations.any { it is KParameterRequireNonNull },
             parameter.isOptional,
             parameterNameConverter(parameter.getAliasOrName()!!),
             parameter.type.classifier as KClass<*>

--- a/src/main/kotlin/com/mapk/core/ValueParameter.kt
+++ b/src/main/kotlin/com/mapk/core/ValueParameter.kt
@@ -1,8 +1,6 @@
 package com.mapk.core
 
-import com.mapk.annotations.KParameterRequireNonNull
 import kotlin.reflect.KClass
-import kotlin.reflect.KParameter
 
 interface ValueParameter<T : Any> {
     val annotations: List<Annotation>
@@ -10,26 +8,4 @@ interface ValueParameter<T : Any> {
     val isOptional: Boolean
     val name: String
     val requiredClazz: KClass<T>
-}
-
-// TODO: 仮置き、ArgumentBinder.Valueでimplementした方が良いと感じるが一旦実装を分けている
-internal class ValueParameterImpl<T : Any>(
-    override val annotations: List<Annotation>,
-    override val isNullable: Boolean,
-    override val isOptional: Boolean,
-    override val name: String,
-    override val requiredClazz: KClass<T>
-) : ValueParameter<T> {
-    companion object {
-        fun newInstance(
-            parameter: KParameter,
-            parameterNameConverter: (String) -> String
-        ): ValueParameter<*> = ValueParameterImpl(
-            parameter.annotations,
-            parameter.annotations.any { it is KParameterRequireNonNull },
-            parameter.isOptional,
-            parameterNameConverter(parameter.getAliasOrName()!!),
-            parameter.type.classifier as KClass<*>
-        )
-    }
 }

--- a/src/test/kotlin/com/mapk/core/KParameterFlattenTest.kt
+++ b/src/test/kotlin/com/mapk/core/KParameterFlattenTest.kt
@@ -1,0 +1,45 @@
+package com.mapk.core
+
+import com.mapk.annotations.KParameterFlatten
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("パラメータのフラット化テスト")
+class KParameterFlattenTest {
+    data class InnerDst1(val quxQux: Int)
+    data class InnerDst2(val quuxQuux: Int)
+
+    data class Dst(
+        val fooFoo: Int,
+        val barBar: Int,
+        @KParameterFlatten
+        val bazBaz: InnerDst1,
+        @KParameterFlatten(fieldNameToPrefix = false)
+        val corgeCorge: InnerDst2
+    )
+
+    companion object {
+        val expectedParams: Set<String> = linkedSetOf("fooFoo", "barBar", "bazBazQuxQux", "quuxQuux")
+        val expected: Dst = Dst(0, 1, InnerDst1(2), InnerDst2(3))
+    }
+
+    @Test
+    fun test() {
+        val function = KFunctionForCall(::Dst, { it })
+
+        function.requiredParameters.forEach {
+            assertTrue(expectedParams.contains(it.name))
+        }
+
+        val adaptor = function.getArgumentAdaptor()
+        expectedParams.forEachIndexed { i, str ->
+            adaptor.putIfAbsent(str, i)
+        }
+        assertTrue(adaptor.isFullInitialized())
+
+        val actual = function.call(adaptor)
+        assertEquals(expected, actual)
+    }
+}

--- a/src/test/kotlin/com/mapk/core/KParameterFlattenTest.kt
+++ b/src/test/kotlin/com/mapk/core/KParameterFlattenTest.kt
@@ -25,7 +25,7 @@ class KParameterFlattenTest {
         val bazBaz: InnerDst1,
         @KParameterFlatten(fieldNameToPrefix = false)
         val corgeCorge: InnerDst2,
-        @KParameterFlatten(namingConvention = NameJoiner.Kebab::class)
+        @KParameterFlatten(nameJoiner = NameJoiner.Kebab::class)
         val garplyGarply: InnerDst3
     )
 

--- a/src/test/kotlin/com/mapk/core/KParameterFlattenTest.kt
+++ b/src/test/kotlin/com/mapk/core/KParameterFlattenTest.kt
@@ -1,6 +1,8 @@
 package com.mapk.core
 
 import com.mapk.annotations.KParameterFlatten
+import io.mockk.spyk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
@@ -27,7 +29,8 @@ class KParameterFlattenTest {
 
     @Test
     fun test() {
-        val function = KFunctionForCall(::Dst, { it })
+        val spiedFunction = spyk(::Dst)
+        val function = KFunctionForCall(spiedFunction, { it })
 
         function.requiredParameters.forEach {
             assertTrue(expectedParams.contains(it.name))
@@ -41,5 +44,6 @@ class KParameterFlattenTest {
 
         val actual = function.call(adaptor)
         assertEquals(expected, actual)
+        verify(exactly = 1) { spiedFunction.call(*anyVararg()) }
     }
 }

--- a/src/test/kotlin/com/mapk/core/KParameterFlattenTest.kt
+++ b/src/test/kotlin/com/mapk/core/KParameterFlattenTest.kt
@@ -1,5 +1,6 @@
 package com.mapk.core
 
+import com.mapk.annotations.KConstructor
 import com.mapk.annotations.KParameterFlatten
 import io.mockk.spyk
 import io.mockk.verify
@@ -12,6 +13,10 @@ import org.junit.jupiter.api.Test
 class KParameterFlattenTest {
     data class InnerDst1(val quxQux: Int)
     data class InnerDst2(val quuxQuux: Int)
+    data class InnerDst3(val graultGrault: String) {
+        @KConstructor
+        constructor(graultGrault: Int) : this(graultGrault.toString())
+    }
 
     data class Dst(
         val fooFoo: Int,
@@ -19,12 +24,15 @@ class KParameterFlattenTest {
         @KParameterFlatten
         val bazBaz: InnerDst1,
         @KParameterFlatten(fieldNameToPrefix = false)
-        val corgeCorge: InnerDst2
+        val corgeCorge: InnerDst2,
+        @KParameterFlatten(namingConvention = NameJoiner.Kebab::class)
+        val garplyGarply: InnerDst3
     )
 
     companion object {
-        val expectedParams: Set<String> = linkedSetOf("fooFoo", "barBar", "bazBazQuxQux", "quuxQuux")
-        val expected: Dst = Dst(0, 1, InnerDst1(2), InnerDst2(3))
+        val expectedParams: Set<String> =
+            linkedSetOf("fooFoo", "barBar", "bazBazQuxQux", "quuxQuux", "garplyGarply-graultGrault")
+        val expected: Dst = Dst(0, 1, InnerDst1(2), InnerDst2(3), InnerDst3("4"))
     }
 
     @Test

--- a/src/test/kotlin/com/mapk/core/NameJoinerTest.kt
+++ b/src/test/kotlin/com/mapk/core/NameJoinerTest.kt
@@ -1,0 +1,104 @@
+package com.mapk.core
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("NameJoinerの名前結合処理が正しいかのテスト")
+class NameJoinerTest {
+    companion object {
+        const val prefix = "prefix"
+        const val suffix = "suffix"
+    }
+
+    @Nested
+    @DisplayName("Camel")
+    inner class CamelTest {
+        private val camel = NameJoiner.Camel
+
+        @Test
+        @DisplayName("prefixが空文字")
+        fun emptyPrefix() {
+            assertEquals(suffix, camel.join("", suffix))
+        }
+
+        @Test
+        @DisplayName("suffixが空文字列")
+        fun emptySuffix() {
+            assertEquals(prefix, camel.join(prefix, ""))
+        }
+
+        @Test
+        @DisplayName("suffixが1文字")
+        fun singleSuffix() {
+            assertEquals("${prefix}A", camel.join(prefix, "a"))
+        }
+
+        @Test
+        @DisplayName("通常結合")
+        fun normal() {
+            assertEquals("${prefix}Suffix", camel.join(prefix, suffix))
+        }
+    }
+
+    @Nested
+    @DisplayName("Snake")
+    inner class SnakeTest {
+        private val snake = NameJoiner.Snake
+
+        @Test
+        @DisplayName("prefixが空文字")
+        fun emptyPrefix() {
+            assertEquals(suffix, snake.join("", suffix))
+        }
+
+        @Test
+        @DisplayName("suffixが空文字列")
+        fun emptySuffix() {
+            assertEquals(prefix, snake.join(prefix, ""))
+        }
+
+        @Test
+        @DisplayName("suffixが1文字")
+        fun singleSuffix() {
+            assertEquals("${prefix}_a", snake.join(prefix, "a"))
+        }
+
+        @Test
+        @DisplayName("通常結合")
+        fun normal() {
+            assertEquals("${prefix}_$suffix", snake.join(prefix, suffix))
+        }
+    }
+
+    @Nested
+    @DisplayName("Kebab")
+    inner class KebabTest {
+        private val kebab = NameJoiner.Kebab
+
+        @Test
+        @DisplayName("prefixが空文字")
+        fun emptyPrefix() {
+            assertEquals(suffix, kebab.join("", suffix))
+        }
+
+        @Test
+        @DisplayName("suffixが空文字列")
+        fun emptySuffix() {
+            assertEquals(prefix, kebab.join(prefix, ""))
+        }
+
+        @Test
+        @DisplayName("suffixが1文字")
+        fun singleSuffix() {
+            assertEquals("$prefix-a", kebab.join(prefix, "a"))
+        }
+
+        @Test
+        @DisplayName("通常結合")
+        fun normal() {
+            assertEquals("$prefix-$suffix", kebab.join(prefix, suffix))
+        }
+    }
+}


### PR DESCRIPTION
# パラメータをネストさせてのマッピングに対応
以下のように、`Dst`の初期化時に`InnerDst`も同時に初期化したい場合、`KParameterFlatten`アノテーションを用いることで同時にマッピングを行えるよう機能追加を行った。

この例の場合、`KFunctionForCall`は`fooFoo`, `barBar`, `bazBazQuxQux`の3パラメータについて初期化を要求する。

```kotlin
data class InnerDst(val quxQux: Int)

data class Dst(
    val fooFoo: Int,
    val barBar: Int,
    @KParameterFlatten
    val bazBaz: InnerDst
)
```

## KParameterFlattenについて
`KParameterFlatten`アノテーションでは以下2点を指定できる。

- フィールド名をプレフィックスとして用いるか（デフォルト = `true`）
- フィールド名をプレフィックスにする場合どのように結合するか（デフォルト = キャメルケース）

### NameJoinerについて
`NameJoiner`は`abstract class`であり、これを継承した`object`(シングルトン)を作ることでオリジナルの`NamingJoiner`を渡すことで結合処理を行うことができる。

# その他修正
`KParameterRequireNonNull`への対応が漏れていた問題を修正した。