### PR TITLE
Refactors.

### DIFF
--- a/.idea/Shared.iml
+++ b/.idea/Shared.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -15,6 +15,7 @@ import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.functions
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.jvm.jvmName
 import org.jetbrains.annotations.TestOnly
 
 class KFunctionForCall<T> internal constructor(
@@ -106,7 +107,7 @@ internal fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: Paramete
 
     if (constructors.isEmpty()) return KFunctionForCall(this.primaryConstructor!!, parameterNameConverter)
 
-    throw IllegalArgumentException("Find multiple target.")
+    throw IllegalArgumentException("${this.jvmName} has multiple ${KConstructor::class.jvmName}.")
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -49,11 +49,7 @@ class KFunctionForCall<T> internal constructor(
             .filter { it.kind == KParameter.Kind.VALUE && !it.isUseDefaultArgument() }
             .map { it.toArgumentBinder(parameterNameConverter) }
 
-        bucketGenerator = BucketGenerator(
-            parameters,
-            binders,
-            instance
-        )
+        bucketGenerator = BucketGenerator(parameters, binders, instance)
 
         val tempList = ArrayList<ValueParameter<*>>(binders.size)
         val tempMap = HashMap<String, ValueParameter<*>>(binders.size)

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -88,16 +88,19 @@ class KFunctionForCall<T> internal constructor(
 
 @Suppress("UNCHECKED_CAST")
 internal fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: ParameterNameConverter): KFunctionForCall<T> {
-    val factoryConstructor: List<KFunctionForCall<T>> =
-        this.companionObjectInstance?.let { companionObject ->
-            companionObject::class.functions
-                .filter { it.annotations.any { annotation -> annotation is KConstructor } }
-                .map { KFunctionForCall(it, parameterNameConverter, companionObject) as KFunctionForCall<T> }
-        } ?: emptyList()
+    val constructors = ArrayList<KFunctionForCall<T>>()
 
-    val constructors: List<KFunctionForCall<T>> = factoryConstructor + this.constructors
+    this.companionObjectInstance?.let { companionObject ->
+        companionObject::class.functions
+            .filter { it.annotations.any { annotation -> annotation is KConstructor } }
+            .forEach {
+                constructors.add(KFunctionForCall(it, parameterNameConverter, companionObject) as KFunctionForCall<T>)
+            }
+    }
+
+    this.constructors
         .filter { it.annotations.any { annotation -> annotation is KConstructor } }
-        .map { KFunctionForCall(it, parameterNameConverter) }
+        .forEach { constructors.add(KFunctionForCall(it, parameterNameConverter)) }
 
     if (constructors.size == 1) return constructors.single()
 


### PR DESCRIPTION
# 軽微な修正
- `KFunctionForCall`の初期化時のループを削減
- クラスからの`KFunctionForCall`取得を効率化
- `KConstructor`を1クラスに複数振った場合のエラーメッセージを読みやすいよう修正
- IDE周りで生成されたファイルの追加