### PR TITLE
Commonization and optimization of functions.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.12"
+version = "0.13"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/kotlin/com/mapk/core/Functions.kt
+++ b/src/main/kotlin/com/mapk/core/Functions.kt
@@ -18,6 +18,6 @@ inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionsFromCompanion
     }
 }
 
-inline fun <reified A : Annotation, T : Any> Collection<KFunction<T>>.getAnnotatedFunctions(): List<KFunction<T>> {
+inline fun <reified A : Annotation, T> Collection<KFunction<T>>.getAnnotatedFunctions(): List<KFunction<T>> {
     return filter { function -> function.annotations.any { it is A } }
 }

--- a/src/main/kotlin/com/mapk/core/Functions.kt
+++ b/src/main/kotlin/com/mapk/core/Functions.kt
@@ -17,3 +17,7 @@ inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionFromCompanionO
         }
     }
 }
+
+inline fun <reified A : Annotation, T : Any> Collection<KFunction<T>>.getAnnotatedFunctions(): List<KFunction<T>> {
+    return filter { function -> function.annotations.any { it is A } }
+}

--- a/src/main/kotlin/com/mapk/core/Functions.kt
+++ b/src/main/kotlin/com/mapk/core/Functions.kt
@@ -1,0 +1,20 @@
+package com.mapk.core
+
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.companionObject
+import kotlin.reflect.full.functions
+
+inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionFromCompanionObject(): List<Pair<KFunction<*>, Any>>? {
+    return this.companionObject?.let { companionObject ->
+        val temp = companionObject.functions.filter { functions -> functions.annotations.any { it is A } }
+
+        if (temp.isEmpty()) {
+            // 空ならその後の処理をしてもしょうがないのでnullに合わせる
+            null
+        } else {
+            val instance = companionObject.objectInstance!!
+            temp.map { it to instance }
+        }
+    }
+}

--- a/src/main/kotlin/com/mapk/core/Functions.kt
+++ b/src/main/kotlin/com/mapk/core/Functions.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.full.companionObject
 import kotlin.reflect.full.functions
 
-inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionFromCompanionObject(): List<Pair<KFunction<*>, Any>>? {
+inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionFromCompanionObject(): Pair<Any, List<KFunction<*>>>? {
     return this.companionObject?.let { companionObject ->
         val temp = companionObject.functions.filter { functions -> functions.annotations.any { it is A } }
 
@@ -13,8 +13,7 @@ inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionFromCompanionO
             // 空ならその後の処理をしてもしょうがないのでnullに合わせる
             null
         } else {
-            val instance = companionObject.objectInstance!!
-            temp.map { it to instance }
+            companionObject.objectInstance!! to temp
         }
     }
 }

--- a/src/main/kotlin/com/mapk/core/Functions.kt
+++ b/src/main/kotlin/com/mapk/core/Functions.kt
@@ -2,6 +2,7 @@ package com.mapk.core
 
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
 import kotlin.reflect.full.companionObject
 import kotlin.reflect.full.functions
 
@@ -21,3 +22,5 @@ inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionsFromCompanion
 inline fun <reified A : Annotation, T> Collection<KFunction<T>>.getAnnotatedFunctions(): List<KFunction<T>> {
     return filter { function -> function.annotations.any { it is A } }
 }
+
+fun KParameter.getKClass(): KClass<*> = type.classifier as KClass<*>

--- a/src/main/kotlin/com/mapk/core/Functions.kt
+++ b/src/main/kotlin/com/mapk/core/Functions.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.full.companionObject
 import kotlin.reflect.full.functions
 
-inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionFromCompanionObject(): Pair<Any, List<KFunction<*>>>? {
+inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionsFromCompanionObject(): Pair<Any, List<KFunction<*>>>? {
     return this.companionObject?.let { companionObject ->
         val temp = companionObject.functions.filter { functions -> functions.annotations.any { it is A } }
 

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -89,7 +89,7 @@ class KFunctionForCall<T> internal constructor(
 internal fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: ParameterNameConverter): KFunctionForCall<T> {
     val constructors = ArrayList<KFunctionForCall<T>>()
 
-    this.getAnnotatedFunctionFromCompanionObject<KConstructor>()?.let { (instance, functions) ->
+    this.getAnnotatedFunctionsFromCompanionObject<KConstructor>()?.let { (instance, functions) ->
         functions.forEach {
             constructors.add(KFunctionForCall(it as KFunction<T>, parameterNameConverter, instance))
         }

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -10,9 +10,7 @@ import com.mapk.core.internal.isUseDefaultArgument
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
-import kotlin.reflect.full.companionObjectInstance
 import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.full.functions
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.jvmName
@@ -91,12 +89,8 @@ class KFunctionForCall<T> internal constructor(
 internal fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: ParameterNameConverter): KFunctionForCall<T> {
     val constructors = ArrayList<KFunctionForCall<T>>()
 
-    this.companionObjectInstance?.let { companionObject ->
-        companionObject::class.functions
-            .filter { it.annotations.any { annotation -> annotation is KConstructor } }
-            .forEach {
-                constructors.add(KFunctionForCall(it, parameterNameConverter, companionObject) as KFunctionForCall<T>)
-            }
+    this.getAnnotatedFunctionFromCompanionObject<KConstructor>()?.forEach { (function, instance) ->
+        constructors.add(KFunctionForCall(function as KFunction<T>, parameterNameConverter, instance))
     }
 
     this.constructors

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -95,9 +95,9 @@ internal fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: Paramete
         }
     }
 
-    this.constructors
-        .filter { it.annotations.any { annotation -> annotation is KConstructor } }
-        .forEach { constructors.add(KFunctionForCall(it, parameterNameConverter)) }
+    this.constructors.getAnnotatedFunctions<KConstructor, T>().forEach {
+        constructors.add(KFunctionForCall(it, parameterNameConverter))
+    }
 
     if (constructors.size == 1) return constructors.single()
 

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -89,8 +89,10 @@ class KFunctionForCall<T> internal constructor(
 internal fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: ParameterNameConverter): KFunctionForCall<T> {
     val constructors = ArrayList<KFunctionForCall<T>>()
 
-    this.getAnnotatedFunctionFromCompanionObject<KConstructor>()?.forEach { (function, instance) ->
-        constructors.add(KFunctionForCall(function as KFunction<T>, parameterNameConverter, instance))
+    this.getAnnotatedFunctionFromCompanionObject<KConstructor>()?.let { (instance, functions) ->
+        functions.forEach {
+            constructors.add(KFunctionForCall(it as KFunction<T>, parameterNameConverter, instance))
+        }
     }
 
     this.constructors

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -123,12 +123,12 @@ private fun KParameter.toArgumentBinder(parameterNameConverter: ParameterNameCon
             parameterNameConverter.toSimple()
         }
 
-        ArgumentBinder.Function((type.classifier as KClass<*>).toKConstructor(converter), index, annotations)
+        ArgumentBinder.Function(getKClass().toKConstructor(converter), index, annotations)
     } ?: ArgumentBinder.Value(
         index,
         annotations,
         isOptional,
         parameterNameConverter.convert(name),
-        type.classifier as KClass<*>
+        getKClass()
     )
 }


### PR DESCRIPTION
# 共通化
- コンパニオンオブジェクトからアノテーションを含む関数を取得する関数を追加
- 関数列からアノテーションを含む関数を取得する関数を追加
- `KParameter`から`KClass`を取得する関数を追加

# 最適化
コンパニオンオブジェクトから関数を取得する際、当初以下のように処理を行っていた。

1. コンパニオンオブジェクトのインスタンスを取得する
2. インスタンスが取得できればクラスを取得する
3. クラスから関数を取得する

この順序では、関数の有無にかかわらず1と2が走るという問題が有った。
また、コンパニオンオブジェクトのインスタンス取得よりもクラス取得の方が高速であった。

このため、処理を以下の順序に改め、インスタンス取得の回数を減らした。

1. コンパニオンオブジェクトのクラスを取得
2. クラスを取得できれば関数を取得する
3. 関数を取得できればインスタンスを取得する