### PR TITLE
Fine-grained optimization.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.15"
+version = "0.16"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
     // https://mvnrepository.com/artifact/io.mockk/mockk
-    testImplementation("io.mockk:mockk:1.9.3")
+    testImplementation("io.mockk:mockk:1.10.0")
 }
 
 tasks {

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -22,7 +22,7 @@ class KFunctionForCall<T> internal constructor(
     parameterNameConverter: ParameterNameConverter,
     instance: Any? = null
 ) {
-    constructor(function: KFunction<T>, parameterNameConverter: (String) -> String, instance: Any? = null) : this(
+    constructor(function: KFunction<T>, parameterNameConverter: ((String) -> String)?, instance: Any? = null) : this(
         function,
         ParameterNameConverter.Simple(parameterNameConverter),
         instance
@@ -108,7 +108,7 @@ internal fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: Paramete
 }
 
 @Suppress("UNCHECKED_CAST")
-fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: (String) -> String): KFunctionForCall<T> =
+fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: ((String) -> String)?): KFunctionForCall<T> =
     this.toKConstructor(ParameterNameConverter.Simple(parameterNameConverter))
 
 private fun KParameter.toArgumentBinder(parameterNameConverter: ParameterNameConverter): ArgumentBinder {

--- a/src/main/kotlin/com/mapk/core/internal/ArgumentBucket.kt
+++ b/src/main/kotlin/com/mapk/core/internal/ArgumentBucket.kt
@@ -31,7 +31,7 @@ internal class ArgumentBucket(
             }
         }
 
-        initializationStatuses = initializationStatus.toList()
+        initializationStatuses = initializationStatus.asList()
         isInitialized = count == initializationStatus.size
         size = count
     }

--- a/src/main/kotlin/com/mapk/core/internal/ParameterNameConverter.kt
+++ b/src/main/kotlin/com/mapk/core/internal/ParameterNameConverter.kt
@@ -2,14 +2,15 @@ package com.mapk.core.internal
 
 import com.mapk.core.NameJoiner
 
-internal sealed class ParameterNameConverter {
-    protected abstract val converter: (String) -> String
+internal sealed class ParameterNameConverter(protected val converter: ((String) -> String)?) {
     abstract fun convert(name: String): String
     abstract fun nest(infix: String, nameJoiner: NameJoiner): WithPrefix
     abstract fun toSimple(): Simple
 
-    class Simple(override val converter: (String) -> String) : ParameterNameConverter() {
-        override fun convert(name: String) = converter(name)
+    protected fun convertedOrName(name: String): String = converter?.invoke(name) ?: name
+
+    class Simple(converter: ((String) -> String)?) : ParameterNameConverter(converter) {
+        override fun convert(name: String) = convertedOrName(name)
         override fun nest(infix: String, nameJoiner: NameJoiner) = WithPrefix(infix, nameJoiner, converter)
         override fun toSimple(): Simple = this
     }
@@ -17,12 +18,12 @@ internal sealed class ParameterNameConverter {
     class WithPrefix(
         prefix: String,
         private val nameJoiner: NameJoiner,
-        override val converter: (String) -> String
-    ) : ParameterNameConverter() {
-        private val prefix = converter(prefix)
+        converter: ((String) -> String)?
+    ) : ParameterNameConverter(converter) {
+        private val prefix = convertedOrName(prefix)
 
         // 結合を伴う変換では、「双方変換 -> 結合」の順で処理を行う
-        override fun convert(name: String) = converter(name).let { nameJoiner.join(prefix, it) }
+        override fun convert(name: String) = convertedOrName(name).let { nameJoiner.join(prefix, it) }
         override fun nest(infix: String, nameJoiner: NameJoiner) = WithPrefix(convert(infix), nameJoiner, converter)
         override fun toSimple(): Simple = Simple(converter)
     }


### PR DESCRIPTION
# 修正
- `ArgumentBucket`生成時、`toList`を`asList`として処理コストを低減
- `KFunctionForCall`生成時、ループをまとめることで処理コストを低減
- パラメータ名変換処理で、「変換が無い場合`null` = 処理しない」とすることで処理コストを低減

# その他
- `MockK`のアップデート