### PR TITLE
Refactor.

### DIFF
--- a/src/main/kotlin/com/mapk/core/Functions.kt
+++ b/src/main/kotlin/com/mapk/core/Functions.kt
@@ -1,10 +1,13 @@
 package com.mapk.core
 
+import com.mapk.annotations.KConstructor
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.companionObject
 import kotlin.reflect.full.functions
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.jvmName
 
 inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionsFromCompanionObject(): Pair<Any, List<KFunction<*>>>? {
     return this.companionObject?.let { companionObject ->
@@ -21,6 +24,27 @@ inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionsFromCompanion
 
 inline fun <reified A : Annotation, T> Collection<KFunction<T>>.getAnnotatedFunctions(): List<KFunction<T>> {
     return filter { function -> function.annotations.any { it is A } }
+}
+
+@Suppress("UNCHECKED_CAST")
+fun <T : Any> KClass<T>.getKConstructor(): Pair<Any?, KFunction<T>> {
+    val constructors = ArrayList<Pair<Any?, KFunction<T>>>()
+
+    this.getAnnotatedFunctionsFromCompanionObject<KConstructor>()?.let { (instance, functions) ->
+        functions.forEach {
+            constructors.add(instance to it as KFunction<T>)
+        }
+    }
+
+    this.constructors.getAnnotatedFunctions<KConstructor, T>().forEach {
+        constructors.add(null to it)
+    }
+
+    if (constructors.size == 1) return constructors.single()
+
+    if (constructors.isEmpty()) return null to this.primaryConstructor!!
+
+    throw IllegalArgumentException("${this.jvmName} has multiple ${KConstructor::class.jvmName}.")
 }
 
 fun KParameter.getKClass(): KClass<*> = type.classifier as KClass<*>

--- a/src/main/kotlin/com/mapk/core/Functions.kt
+++ b/src/main/kotlin/com/mapk/core/Functions.kt
@@ -1,13 +1,10 @@
 package com.mapk.core
 
-import com.mapk.annotations.KConstructor
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.companionObject
 import kotlin.reflect.full.functions
-import kotlin.reflect.full.primaryConstructor
-import kotlin.reflect.jvm.jvmName
 
 inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionsFromCompanionObject(): Pair<Any, List<KFunction<*>>>? {
     return this.companionObject?.let { companionObject ->
@@ -24,27 +21,6 @@ inline fun <reified A : Annotation> KClass<*>.getAnnotatedFunctionsFromCompanion
 
 inline fun <reified A : Annotation, T> Collection<KFunction<T>>.getAnnotatedFunctions(): List<KFunction<T>> {
     return filter { function -> function.annotations.any { it is A } }
-}
-
-@Suppress("UNCHECKED_CAST")
-fun <T : Any> KClass<T>.getKConstructor(): Pair<Any?, KFunction<T>> {
-    val constructors = ArrayList<Pair<Any?, KFunction<T>>>()
-
-    this.getAnnotatedFunctionsFromCompanionObject<KConstructor>()?.let { (instance, functions) ->
-        functions.forEach {
-            constructors.add(instance to it as KFunction<T>)
-        }
-    }
-
-    this.constructors.getAnnotatedFunctions<KConstructor, T>().forEach {
-        constructors.add(null to it)
-    }
-
-    if (constructors.size == 1) return constructors.single()
-
-    if (constructors.isEmpty()) return null to this.primaryConstructor!!
-
-    throw IllegalArgumentException("${this.jvmName} has multiple ${KConstructor::class.jvmName}.")
 }
 
 fun KParameter.getKClass(): KClass<*> = type.classifier as KClass<*>

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -5,6 +5,7 @@ import com.mapk.core.internal.ArgumentBinder
 import com.mapk.core.internal.BucketGenerator
 import com.mapk.core.internal.ParameterNameConverter
 import com.mapk.core.internal.getAliasOrName
+import com.mapk.core.internal.getKConstructor
 import com.mapk.core.internal.isUseDefaultArgument
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -1,6 +1,5 @@
 package com.mapk.core
 
-import com.mapk.annotations.KConstructor
 import com.mapk.annotations.KParameterFlatten
 import com.mapk.core.internal.ArgumentBinder
 import com.mapk.core.internal.BucketGenerator
@@ -11,9 +10,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.isAccessible
-import kotlin.reflect.jvm.jvmName
 import org.jetbrains.annotations.TestOnly
 
 class KFunctionForCall<T> internal constructor(
@@ -86,30 +83,10 @@ class KFunctionForCall<T> internal constructor(
     }
 }
 
-@Suppress("UNCHECKED_CAST")
-internal fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: ParameterNameConverter): KFunctionForCall<T> {
-    val constructors = ArrayList<KFunctionForCall<T>>()
-
-    this.getAnnotatedFunctionsFromCompanionObject<KConstructor>()?.let { (instance, functions) ->
-        functions.forEach {
-            constructors.add(KFunctionForCall(it as KFunction<T>, parameterNameConverter, instance))
-        }
-    }
-
-    this.constructors.getAnnotatedFunctions<KConstructor, T>().forEach {
-        constructors.add(KFunctionForCall(it, parameterNameConverter))
-    }
-
-    if (constructors.size == 1) return constructors.single()
-
-    if (constructors.isEmpty()) return KFunctionForCall(this.primaryConstructor!!, parameterNameConverter)
-
-    throw IllegalArgumentException("${this.jvmName} has multiple ${KConstructor::class.jvmName}.")
-}
-
-@Suppress("UNCHECKED_CAST")
 fun <T : Any> KClass<T>.toKConstructor(parameterNameConverter: ((String) -> String)?): KFunctionForCall<T> =
-    this.toKConstructor(ParameterNameConverter.Simple(parameterNameConverter))
+    this.getKConstructor().let { (instance, function) ->
+        KFunctionForCall(function, ParameterNameConverter.Simple(parameterNameConverter), instance)
+    }
 
 private fun KParameter.toArgumentBinder(parameterNameConverter: ParameterNameConverter): ArgumentBinder {
     val name = getAliasOrName()!!
@@ -124,7 +101,9 @@ private fun KParameter.toArgumentBinder(parameterNameConverter: ParameterNameCon
             parameterNameConverter.toSimple()
         }
 
-        ArgumentBinder.Function(getKClass().toKConstructor(converter), index, annotations)
+        getKClass().getKConstructor().let { (instance, function) ->
+            ArgumentBinder.Function(KFunctionForCall(function, converter, instance), index, annotations)
+        }
     } ?: ArgumentBinder.Value(
         index,
         annotations,

--- a/src/main/kotlin/com/mapk/core/internal/Functions.kt
+++ b/src/main/kotlin/com/mapk/core/internal/Functions.kt
@@ -1,10 +1,16 @@
 package com.mapk.core.internal
 
+import com.mapk.annotations.KConstructor
 import com.mapk.annotations.KParameterAlias
 import com.mapk.annotations.KUseDefaultArgument
+import com.mapk.core.getAnnotatedFunctions
+import com.mapk.core.getAnnotatedFunctionsFromCompanionObject
 import java.lang.IllegalArgumentException
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.jvmName
 
 /**
@@ -23,4 +29,25 @@ internal fun KParameter.isUseDefaultArgument(): Boolean {
         return true
     }
     return false
+}
+
+@Suppress("UNCHECKED_CAST")
+internal fun <T : Any> KClass<T>.getKConstructor(): Pair<Any?, KFunction<T>> {
+    val constructors = ArrayList<Pair<Any?, KFunction<T>>>()
+
+    this.getAnnotatedFunctionsFromCompanionObject<KConstructor>()?.let { (instance, functions) ->
+        functions.forEach {
+            constructors.add(instance to it as KFunction<T>)
+        }
+    }
+
+    this.constructors.getAnnotatedFunctions<KConstructor, T>().forEach {
+        constructors.add(null to it)
+    }
+
+    if (constructors.size == 1) return constructors.single()
+
+    if (constructors.isEmpty()) return null to this.primaryConstructor!!
+
+    throw IllegalArgumentException("${this.jvmName} has multiple ${KConstructor::class.jvmName}.")
 }


### PR DESCRIPTION
後続での共通化のため、`KConstructor`の取り出し関連を切り出し。