### PR TITLE
Update Kotlin and refactors.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.17"
+version = "0.18"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("maven")
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.4.0"
+    id("org.jetbrains.kotlin.jvm") version "1.4.10"
     id("org.jlleitschuh.gradle.ktlint") version "9.3.0"
     id("jacoco")
 }

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -3,6 +3,7 @@ package com.mapk.core
 import com.mapk.annotations.KParameterFlatten
 import com.mapk.core.internal.ArgumentBinder
 import com.mapk.core.internal.BucketGenerator
+import com.mapk.core.internal.FullInitializedFunctionWrapper
 import com.mapk.core.internal.ParameterNameConverter
 import com.mapk.core.internal.getAliasOrName
 import com.mapk.core.internal.getKConstructor
@@ -13,7 +14,6 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.jvm.isAccessible
-import kotlin.reflect.jvm.javaConstructor
 
 class KFunctionForCall<T> internal constructor(
     @TestOnly
@@ -28,9 +28,7 @@ class KFunctionForCall<T> internal constructor(
     )
 
     @TestOnly
-    internal val fullInitializedFunctionLambda: (Array<Any?>) -> T = function.javaConstructor?.let {
-        { values -> it.newInstance(*values) }
-    } ?: { function.call(*it) }
+    internal val fullInitializedWrapper: FullInitializedFunctionWrapper<T>
 
     @TestOnly
     internal val parameters: List<KParameter> = function.parameters
@@ -47,6 +45,8 @@ class KFunctionForCall<T> internal constructor(
 
         // この関数には確実にアクセスするためアクセシビリティ書き換え
         function.isAccessible = true
+
+        fullInitializedWrapper = FullInitializedFunctionWrapper(function, instance, parameters.size)
 
         val tempBinders = ArrayList<ArgumentBinder>()
         val tempList = ArrayList<ValueParameter<*>>()
@@ -86,7 +86,7 @@ class KFunctionForCall<T> internal constructor(
 
     fun call(adaptor: ArgumentAdaptor): T {
         val bucket = bucketGenerator.generate(adaptor)
-        return if (bucket.isInitialized) fullInitializedFunctionLambda(bucket.valueArray) else function.callBy(bucket)
+        return if (bucket.isInitialized) fullInitializedWrapper.call(bucket.valueArray) else function.callBy(bucket)
     }
 }
 

--- a/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
+++ b/src/main/kotlin/com/mapk/core/KFunctionForCall.kt
@@ -27,6 +27,7 @@ class KFunctionForCall<T> internal constructor(
         instance
     )
 
+    @TestOnly
     internal val fullInitializedFunctionLambda: (Array<Any?>) -> T = function.javaConstructor?.let {
         { values -> it.newInstance(*values) }
     } ?: { function.call(*it) }

--- a/src/main/kotlin/com/mapk/core/internal/ArgumentBucket.kt
+++ b/src/main/kotlin/com/mapk/core/internal/ArgumentBucket.kt
@@ -7,7 +7,7 @@ import kotlin.reflect.KParameter
 internal class ArgumentBucket(
     private val keyList: List<KParameter>,
     val valueArray: Array<Any?>,
-    initializationStatus: Array<Boolean>,
+    initializationStatus: BooleanArray,
     argumentBinders: List<ArgumentBinder>,
     adaptor: ArgumentAdaptor
 ) : Map<KParameter, Any?> {

--- a/src/main/kotlin/com/mapk/core/internal/BucketGenerator.kt
+++ b/src/main/kotlin/com/mapk/core/internal/BucketGenerator.kt
@@ -9,7 +9,7 @@ internal class BucketGenerator(
     instance: Any?
 ) {
     private val originalValueArray: Array<Any?> = arrayOfNulls(parameters.size)
-    private val originalInitializationStatus: Array<Boolean> = Array(parameters.size) { false }
+    private val originalInitializationStatus: BooleanArray = BooleanArray(parameters.size)
 
     init {
         if (instance != null) {

--- a/src/main/kotlin/com/mapk/core/internal/FullInitializedFunctionWrapper.kt
+++ b/src/main/kotlin/com/mapk/core/internal/FullInitializedFunctionWrapper.kt
@@ -1,0 +1,29 @@
+package com.mapk.core.internal
+
+import kotlin.reflect.KFunction
+import kotlin.reflect.jvm.javaConstructor
+import kotlin.reflect.jvm.javaMethod
+
+internal class FullInitializedFunctionWrapper<T>(function: KFunction<T>, instance: Any?, paramSize: Int) {
+    private val lambda: (Array<Any?>) -> T
+
+    init {
+        val constructor = function.javaConstructor
+
+        lambda = when {
+            constructor != null -> {
+                { constructor.newInstance(*it) }
+            }
+            instance != null -> {
+                val method = function.javaMethod!!
+
+                @Suppress("UNCHECKED_CAST") { method.invoke(it[0], *(it.copyOfRange(1, paramSize))) as T }
+            }
+            else -> {
+                { function.call(*it) }
+            }
+        }
+    }
+
+    fun call(args: Array<Any?>): T = lambda(args)
+}

--- a/src/main/kotlin/com/mapk/core/internal/FullInitializedFunctionWrapper.kt
+++ b/src/main/kotlin/com/mapk/core/internal/FullInitializedFunctionWrapper.kt
@@ -17,7 +17,7 @@ internal class FullInitializedFunctionWrapper<T>(function: KFunction<T>, instanc
             instance != null -> {
                 val method = function.javaMethod!!
 
-                @Suppress("UNCHECKED_CAST") { method.invoke(it[0], *(it.copyOfRange(1, paramSize))) as T }
+                @Suppress("UNCHECKED_CAST") { method.invoke(instance, *(it.copyOfRange(1, paramSize))) as T }
             }
             else -> {
                 { function.call(*it) }

--- a/src/test/kotlin/com/mapk/core/KFunctionForCallTest.kt
+++ b/src/test/kotlin/com/mapk/core/KFunctionForCallTest.kt
@@ -51,7 +51,6 @@ class KFunctionForCallTest {
         fun fromCompanionObject() {
             val function = Companion::class.functions
                 .first { it.name == (KFunctionForCallTest)::declaredOnCompanionObject.name }
-                .let { spyk(it) }
 
             val kFunctionForCall = KFunctionForCall(function, { it }, Companion)
 
@@ -60,7 +59,6 @@ class KFunctionForCallTest {
             adaptor.putIfAbsent("arg2", 2)
             val result = kFunctionForCall.call(adaptor)
             assertEquals("12", result)
-            verify(exactly = 1) { function.call(*anyVararg()) }
         }
 
         private fun func(key: String, value: String = "default"): Pair<String, String> = key to value
@@ -84,7 +82,6 @@ class KFunctionForCallTest {
         fun multipleCall() {
             val function = Companion::class.functions
                 .first { it.name == (KFunctionForCallTest)::declaredOnCompanionObject.name }
-                .let { spyk(it) }
 
             val kFunctionForCall = KFunctionForCall(function, { it }, Companion)
 
@@ -101,8 +98,6 @@ class KFunctionForCallTest {
                 .forEach { adaptor2.putIfAbsent(it.name!!, it.index + 1) }
             val result2 = kFunctionForCall.call(adaptor2)
             assertEquals("23", result2)
-
-            verify(exactly = 2) { function.call(*anyVararg()) }
         }
     }
 

--- a/src/test/kotlin/com/mapk/core/KParameterFlattenTest.kt
+++ b/src/test/kotlin/com/mapk/core/KParameterFlattenTest.kt
@@ -2,8 +2,6 @@ package com.mapk.core
 
 import com.mapk.annotations.KConstructor
 import com.mapk.annotations.KParameterFlatten
-import io.mockk.spyk
-import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
@@ -44,8 +42,7 @@ class KParameterFlattenTest {
 
     @Test
     fun test() {
-        val spiedFunction = spyk(::Dst)
-        val function = KFunctionForCall(spiedFunction, { it })
+        val function = KFunctionForCall(::Dst, { it })
 
         function.requiredParameters.forEach {
             assertTrue(expectedParams.contains(it.name))
@@ -59,6 +56,5 @@ class KParameterFlattenTest {
 
         val actual = function.call(adaptor)
         assertEquals(expected, actual)
-        verify(exactly = 1) { spiedFunction.call(*anyVararg()) }
     }
 }

--- a/src/test/kotlin/com/mapk/core/internal/FullInitializedFunctionWrapperTest.kt
+++ b/src/test/kotlin/com/mapk/core/internal/FullInitializedFunctionWrapperTest.kt
@@ -1,0 +1,56 @@
+package com.mapk.core.internal
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.reflect.full.companionObject
+import kotlin.reflect.full.companionObjectInstance
+import kotlin.reflect.full.functions
+
+@DisplayName("完全初期化時呼び出しのテスト")
+class FullInitializedFunctionWrapperTest {
+    data class Dst(val foo: Int, val bar: String) {
+        companion object {
+            fun of(foo: Int, bar: String) = Dst(foo, bar)
+        }
+    }
+    fun instanceMethod(foo: Int, bar: String) = Dst(foo, bar)
+    private val expected = Dst(1, "2")
+
+    @Test
+    @DisplayName("コンストラクタの場合")
+    fun constructorTest() {
+        val fullInitializedFunctionWrapper = FullInitializedFunctionWrapper(::Dst, null, 2)
+        assertEquals(expected, fullInitializedFunctionWrapper.call(arrayOf(1, "2")))
+    }
+
+    @Test
+    @DisplayName("コンパニオンオブジェクトに定義した関数の場合")
+    fun companionObjectFunTest() {
+        val func = Dst::class.companionObject!!.functions.first { it.name == "of" }
+        val instance = Dst::class.companionObjectInstance!!
+        val fullInitializedFunctionWrapper = FullInitializedFunctionWrapper(
+            func, instance, 3
+        )
+        assertEquals(expected, fullInitializedFunctionWrapper.call(arrayOf(instance, 1, "2")))
+    }
+
+    @Nested
+    @DisplayName("その他の場合")
+    inner class OthersTest {
+        @Test
+        @DisplayName("コンパニオンオブジェクトに定義した関数をメソッドリファレンスで取得した場合")
+        fun companionObjectFunByMethodReferenceTest() {
+            val fullInitializedFunctionWrapper = FullInitializedFunctionWrapper((Dst)::of, null, 2)
+            assertEquals(expected, fullInitializedFunctionWrapper.call(arrayOf(1, "2")))
+        }
+
+        @Test
+        @DisplayName("インスタンスメソッドの場合")
+        fun instanceMethodTest() {
+            val fullInitializedFunctionWrapper = FullInitializedFunctionWrapper(::instanceMethod, null, 2)
+            assertEquals(expected, fullInitializedFunctionWrapper.call(arrayOf(1, "2")))
+        }
+    }
+}


### PR DESCRIPTION
# 内容
- `Kotlin 1.4.10`にアップデート
- 呼び出し対象がコンストラクタかつ引数が完全に初期化されていて、かつ条件に合致する場合、`Java`のコンストラクタ/メソッドを直接呼び出すことでオーバーヘッドを低減
  - コンストラクタの場合
  - クラスからコンパニオンオブジェクトに定義したメソッドを取得した（= インスタンス有りで初期化した）場合
- プリミティブ配列を用いることでオーバーヘッドを低減